### PR TITLE
Fix behaviour on default action

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -25,19 +25,24 @@ local function usage(f)
     f = io.stderr
   end
   f:write(
-    string.format('usage: %s [sync]\n', argv0),
+    string.format('usage: %s sync\n', argv0),
     string.format('usage: %s upgrade\n', argv0),
     string.format('usage: %s refresh\n', argv0),
     string.format('usage: %s install <package-name>\n', argv0),
     string.format('usage: %s search <package-name>\n', argv0),
     string.format('usage: %s uninstall <package-name>\n', argv0),
-    string.format('usage: %s help\n', argv0)
+    string.format('usage: %s [help]\n', argv0)
   )
   os.exit(f ~= io.stderr)
 end
 
 local cmd = table.remove(arg, 1)
--- FIXME 
+if cmd == nil then
+    usage(io.stdout)
+    return
+end
+
+-- FIXME
 package_name = table.remove(arg, 1)
 if cmd == "install" or cmd == "search" or cmd == "uninstall" then
   if package_name == "" or package_name == nil then


### PR DESCRIPTION
When no args are given, the usage will be shown.
This change makes "help" a default command and removes unwanted non zero return code on help usage.